### PR TITLE
Make sure we close peer connections in proxy

### DIFF
--- a/proxy/proxypair.js
+++ b/proxy/proxypair.js
@@ -184,6 +184,10 @@ class ProxyPair {
       this.client.close();
     }
     this.client = null;
+    if (this.peerConnOpen()) {
+      this.pc.close();
+    }
+    this.pc = null;
     if (this.relayIsReady()) {
       this.relay.close();
     }
@@ -236,6 +240,10 @@ class ProxyPair {
 
   isClosed(ws) {
     return void 0 === ws || WebSocket.CLOSED === ws.readyState;
+  }
+
+  peerConnOpen() {
+    return (null !== this.pc) && ('closed' !== this.pc.connectionState);
   }
 
 }


### PR DESCRIPTION
Not closing peer connections was causing UDP sockets to remain open
indefinitely (as reported in ticket #31285). Also made sure we're
closing data channels and connections when the extension is disabled by
the UI.