### PR TITLE
Remove unecessary log messages

### DIFF
--- a/proxy-go/snowflake.go
+++ b/proxy-go/snowflake.go
@@ -90,8 +90,6 @@ func (c *webRTCConn) Read(b []byte) (int, error) {
 func (c *webRTCConn) Write(b []byte) (int, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	// log.Printf("webrtc Write %d %+q", len(b), string(b))
-	log.Printf("Write %d bytes --> WebRTC", len(b))
 	if c.dc != nil {
 		c.dc.Send(b)
 	}
@@ -320,7 +318,6 @@ func makePeerConnectionFromOffer(sdp *webrtc.SessionDescription, config webrtc.C
 			pw.Close()
 		})
 		dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-			log.Printf("OnMessage <--- %d bytes", len(msg.Data))
 			var n int
 			n, err = pw.Write(msg.Data)
 			if err != nil {


### PR DESCRIPTION
Ever since we started scrubbing log messages, with the help of regexes
for https://bugs.torproject.org/21304 logging has become more CPU
intensive due to our use of regular expressions.

Logging the byte count of every incoming and outgoing message at the
proxy-go instances was taking up a lot of CPU and contrubuting to the
high CPU usage seen in https://bugs.torproject.org/33211.