### PR TITLE
Have broker inform proxies of updates

### DIFF
--- a/broker/snowflake-broker_test.go
+++ b/broker/snowflake-broker_test.go
@@ -128,7 +128,7 @@ func TestBroker(t *testing.T) {
 				p.offerChannel <- []byte("fake offer")
 				<-done
 				So(w.Code, ShouldEqual, http.StatusOK)
-				So(w.Body.String(), ShouldEqual, `{"Status":"client match","Offer":"fake offer"}`)
+				So(w.Body.String(), ShouldEqual, `{"Status":"client match","Update":true,"Offer":"fake offer"}`)
 			})
 
 			Convey("return empty 200 OK when no client offer is available.", func() {
@@ -141,7 +141,7 @@ func TestBroker(t *testing.T) {
 				// nil means timeout
 				p.offerChannel <- nil
 				<-done
-				So(w.Body.String(), ShouldEqual, `{"Status":"no match","Offer":""}`)
+				So(w.Body.String(), ShouldEqual, `{"Status":"no match","Update":true,"Offer":""}`)
 				So(w.Code, ShouldEqual, http.StatusOK)
 			})
 		})
@@ -279,7 +279,7 @@ func TestBroker(t *testing.T) {
 
 			<-polled
 			So(wP.Code, ShouldEqual, http.StatusOK)
-			So(wP.Body.String(), ShouldResemble, `{"Status":"client match","Offer":"fake offer"}`)
+			So(wP.Body.String(), ShouldResemble, `{"Status":"client match","Update":true,"Offer":"fake offer"}`)
 			So(ctx.idToSnowflake["ymbcCMto7KHNGYlp"], ShouldNotBeNil)
 			// Follow up with the answer request afterwards
 			wA := httptest.NewRecorder()

--- a/proxy-go/proxy-go_test.go
+++ b/proxy-go/proxy-go_test.go
@@ -247,7 +247,7 @@ func TestBrokerInteractions(t *testing.T) {
 		Convey("polls broker correctly", func() {
 			var err error
 
-			b, err := messages.EncodePollResponse(sampleOffer, true)
+			b, err := messages.EncodePollResponse(sampleOffer, true, true)
 			So(err, ShouldEqual, nil)
 			broker.transport = &MockTransport{
 				http.StatusOK,

--- a/proxy-go/snowflake.go
+++ b/proxy-go/snowflake.go
@@ -41,6 +41,7 @@ var broker *Broker
 var relayURL string
 
 const (
+	version         = "1.0"
 	sessionIDLength = 16
 )
 
@@ -173,7 +174,7 @@ func (b *Broker) pollOffer(sid string) *webrtc.SessionDescription {
 			timeOfNextPoll = now
 		}
 
-		body, err := messages.EncodePollRequest(sid, "standalone")
+		body, err := messages.EncodePollRequest(sid, "standalone", version)
 		if err != nil {
 			log.Printf("Error encoding poll message: %s", err.Error())
 			return nil
@@ -192,7 +193,11 @@ func (b *Broker) pollOffer(sid string) *webrtc.SessionDescription {
 					log.Printf("error reading broker response: %s", err)
 				} else {
 
-					offer, err := messages.DecodePollResponse(body)
+					offer, update, err := messages.DecodePollResponse(body)
+					if update {
+						log.Printf(`There is a new version of the Go standalone snowflake
+                        proxy available. Please update your install.`)
+					}
 					if err != nil {
 						log.Printf("error reading broker response: %s", err.Error())
 						log.Printf("body: %s", body)


### PR DESCRIPTION
This is targeted specifically at the standalone go proxies. Proxies
report their version to the broker and the broker will include an
additional field in their response to indicate whether the proxies
should update. If there is a newer version available, a log message will
br printed after every poll.