### PR TITLE
Reduce SnowflakeTimeout to 20 seconds

### DIFF
--- a/client/lib/snowflake.go
+++ b/client/lib/snowflake.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	ReconnectTimeout = 10 * time.Second
-	SnowflakeTimeout = 30 * time.Second
+	SnowflakeTimeout = 20 * time.Second
 	// How long to wait for the OnOpen callback on a DataChannel.
 	DataChannelTimeout = 10 * time.Second
 )


### PR DESCRIPTION
The underlying smux layer sends a keep-alive ping every 10 seconds. This
modification will allow for one dropped/delayed ping before discarding
the snowflake